### PR TITLE
devcontainerにClaude設定ファイルをマウント

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -31,9 +31,10 @@
   "mounts": [
       "source=${localEnv:HOME}/.ssh/,target=/home/vscode/.ssh/,type=bind,consistency=cached",
       "source=${localEnv:HOME}/.aws/,target=/home/vscode/.aws/,type=bind,consistency=cached",
+      "source=${localEnv:HOME}/.claude/,target=/home/vscode/.claude/,type=bind,consistency=cached",
+      "source=${localEnv:HOME}/.claude.json,target=/home/vscode/.claude.json,type=bind,consistency=cached",
       "source=${localEnv:HOME}/.devcontainer-template/.kube/,target=/home/vscode/.kube/,type=bind,consistency=cached",
-      "source=${localEnv:HOME}/.devcontainer-template/.config/helm/,target=/home/vscode/.config/helm/,type=bind,consistency=cached",
-      "source=${localEnv:HOME}/.devcontainer-template/.claude/,target=/home/vscode/.claude/,type=bind,consistency=cached"
+      "source=${localEnv:HOME}/.devcontainer-template/.config/helm/,target=/home/vscode/.config/helm/,type=bind,consistency=cached"
   ],
 
   // devcontainerに追加する機能の定義

--- a/.devcontainer/init.sh
+++ b/.devcontainer/init.sh
@@ -2,9 +2,10 @@
 
 mkdir -p ~/.ssh
 mkdir -p ~/.aws
+mkdir -p ~/.claude
+touch ~/.claude.json
 mkdir -p ~/.devcontainer-template/.kube
 mkdir -p ~/.devcontainer-template/.config/helm
-mkdir -p ~/.devcontainer-template/.claude
 
 DOCKER_NETWORK=br-devcontainer-template-${USER}
 NETWORK_EXISTS=$(docker network ls --filter name=$DOCKER_NETWORK --format '{{.Name}}')

--- a/.devcontainer/init.sh
+++ b/.devcontainer/init.sh
@@ -3,7 +3,7 @@
 mkdir -p ~/.ssh
 mkdir -p ~/.aws
 mkdir -p ~/.claude
-touch ~/.claude.json
+[ ! -f ~/.claude.json ] && echo '{}' > ~/.claude.json
 mkdir -p ~/.devcontainer-template/.kube
 mkdir -p ~/.devcontainer-template/.config/helm
 


### PR DESCRIPTION
## 概要
Closes #1

ホスト側のClaude設定ファイルとディレクトリをdevcontainerにマウントすることで、コンテナ内でもClaude CLIの設定を利用できるようにしました。

## 変更内容

### [.devcontainer/devcontainer.json](.devcontainer/devcontainer.json)
- `~/.claude/` ディレクトリのマウントを追加
- `~/.claude.json` ファイルのマウントを追加
- 以前の `~/.devcontainer-template/.claude/` マウントを削除（ホスト側の `~/.claude/` に統一）

### [.devcontainer/init.sh](.devcontainer/init.sh)
- ホスト側に `~/.claude/` ディレクトリを作成
- ホスト側に `~/.claude.json` ファイルを作成
- 以前の `~/.devcontainer-template/.claude` 初期化を削除

## 動作確認
- [ ] devcontainerをリビルドして正常に起動すること
- [ ] コンテナ内で `~/.claude/` と `~/.claude.json` が正しくマウントされていること

## 影響範囲
- 既存の開発環境に影響なし（新規マウントポイントの追加のみ）
- ホスト側に Claude 設定ファイルが存在しない場合は、[init.sh](.devcontainer/init.sh) で自動作成される